### PR TITLE
Extracted embedded class and instantiate it on QshFile creating

### DIFF
--- a/qsh/__init__.py
+++ b/qsh/__init__.py
@@ -172,15 +172,15 @@ class OwnOrder:
     def __str__(self):
         return ";".join((str(self.type), str(self.id), str(self.price), str(self.amount_rest)))
 
-class QshFile:
+class QshFileHeader:
+    signature = "QScalp History Data"
+    version = None
+    application = None
+    comment = None
+    created_at = None
+    streams_count = None
 
-    class header:
-        signature     = "QScalp History Data"
-        version       = None
-        application   = None
-        comment       = None
-        created_at    = None
-        streams_count = None
+class QshFile:
 
     fileobj = None
 
@@ -190,21 +190,21 @@ class QshFile:
     def __init__(self, filename=None, mode=None):
         self.fileobj = gzip.open(filename, mode)
 
-        signature = self.read(len(self.header.signature.encode("utf8")))
-
-        if self.header.signature != signature:
+        signature = self.read(len(QshFileHeader.signature.encode("utf8")))
+        if QshFileHeader.signature != signature:
             self.fileobj = io.open(filename, mode)
 
-            signature = self.read(len(self.header.signature.encode("utf8")))
+            signature = self.read(len(QshFileHeader.signature.encode("utf8")))
 
-            if self.header.signature != signature:
+            if QshFileHeader.signature != signature:
                 raise TypeError("Unsupported file format")
 
-        self.header.version       = self.read_byte()
-        self.header.application   = self.read_string()
-        self.header.comment       = self.read_string()
+        self.header = QshFileHeader()
+        self.header.version = self.read_byte()
+        self.header.application = self.read_string()
+        self.header.comment = self.read_string()
         self.last_created_at_milliseconds = to_milliseconds(self.read_datetime())
-        self.header.created_at    = to_datetime(self.last_created_at_milliseconds).replace(tzinfo=self.from_zone).astimezone(self.to_zone)
+        self.header.created_at = to_datetime(self.last_created_at_milliseconds).replace(tzinfo=self.from_zone).astimezone(self.to_zone)
         self.header.streams_count = self.read_byte()
 
     def __enter__(self):

--- a/qsh/__init__.py
+++ b/qsh/__init__.py
@@ -207,6 +207,14 @@ class QshFile:
         self.header.created_at = to_datetime(self.last_created_at_milliseconds).replace(tzinfo=self.from_zone).astimezone(self.to_zone)
         self.header.streams_count = self.read_byte()
 
+        # Last values for read_ord_log_data()
+        self.quotes = {}
+        self.external_quotes = {}
+
+        # Last values for read_quotes_data()
+        self.quotes_last_price = 0
+        self.quotes_dict = {}
+
     def __enter__(self):
         self.fileobj._checkClosed()
         return self
@@ -351,9 +359,6 @@ class QshFile:
 
     last_pushed_deal_id        = 0
 
-    quotes = {}
-    external_quotes = {}
-
     def read_ord_log_data(self):
         """Reads order log data from file"""
         availability_mask = self.read_byte()
@@ -458,10 +463,6 @@ class QshFile:
         message_text      = self.read_string()
 
         return Message(message_timestamp, message_type, message_text)
-
-    # Last values for read_quotes_data()
-    quotes_last_price = 0
-    quotes_dict       = {}
 
     def read_quotes_data(self):
         """Reads quotes data from file"""


### PR DESCRIPTION
There is a bug because of using class-attributes to store data of one record. For example `QshFile.header.created_at` and other.

## How to reproduce:
Let's say we are creating two instances of `QshFile` class to read data from two files and compare them in some way.
The second file creation time will be used as creation time for both objects which is not right.

```
import glob

import qsh

# Open all files from current directory. Assume that those files have different creation time
qsh_list = []
for filename in glob.glob('*.qsh'):
  qsh_file = qsh.open(filename)
  qsh_list.append(qsh_file)

# Build a list of creation times from all opened files
created_at_list = [qfile.header.created_at for qfile in qsh_list]

# All opened files share creation time from the last one :\
assert all([created_at == created_at_list[-1] for created_at in created_at_list]) is True
```

## Proposed changes:
- Extract `QshFile.header` embedded class into `QshFileHeader` class
- Create a new instance of `QshFileHeader` class on creation of `QshFile` instance
