### PR TITLE
Use collections.namedtuple for data-classes

### DIFF
--- a/qsh/__init__.py
+++ b/qsh/__init__.py
@@ -2,6 +2,7 @@ import io
 import gzip
 import struct
 import datetime
+from collections import namedtuple
 from dateutil import tz
 
 def open(filename, mode="rb"):
@@ -29,7 +30,12 @@ class StreamType:
     AUX_INFO   = 96
     ORD_LOG    = 112
 
-class OrdLogEntry:
+OrdLogNamedTuple = namedtuple(
+    'OrdLogNamedTuple',
+    'actions_mask,exchange_timestamp,exchange_order_id,order_price,amount,amount_rest,deal_id,deal_price,oi_after_deal',
+)
+
+class OrdLogEntry(OrdLogNamedTuple):
     class DataFlag:
         DATETIME          = 1
         ORDER_ID          = 2
@@ -58,21 +64,12 @@ class OrdLogEntry:
         CANCELED_GROUP     = 16384
         CROSS_TRADE        = 32768
 
-    def __init__(self, actions_mask, exchange_timestamp, exchange_order_id, order_price, amount, amount_rest, deal_id, deal_price, oi_after_deal):
-        self.actions_mask       = actions_mask
-        self.exchange_timestamp = exchange_timestamp
-        self.exchange_order_id  = exchange_order_id
-        self.order_price        = order_price
-        self.amount             = amount
-        self.amount_rest        = amount_rest
-        self.deal_id            = deal_id
-        self.deal_price         = deal_price
-        self.oi_after_deal      = oi_after_deal
+DealEntryNamedTuple = namedtuple(
+    'DealEntryNamedTuple',
+    'type,id,timestamp,price,volume,oi,order_id',
+)
 
-    def __str__(self):
-        return ";".join((str(self.actions_mask), self.exchange_timestamp.isoformat(" "), str(self.exchange_order_id), str(self.order_price), str(self.amount), str(self.amount_rest), str(self.deal_id), str(self.deal_price), str(self.oi_after_deal)))
-
-class DealEntry:
+class DealEntry(DealEntryNamedTuple):
     class DataFlag:
         TYPE     = 3
         DATETIME = 4
@@ -88,19 +85,12 @@ class DealEntry:
         SELL     = 2
         RESERVED = 3
 
-    def __init__(self, deal_type, deal_id, timestamp, price, volume, oi, order_id):
-        self.type      = deal_type
-        self.id        = deal_id
-        self.timestamp = timestamp
-        self.price     = price
-        self.volume    = volume
-        self.oi        = oi
-        self.order_id  = order_id
+AuxInfoNamedTuple = namedtuple(
+    'AuxInfoNamedTuple',
+    'timestamp,price,ask_total,bid_total,oi,hi_limit,low_limit,deposit,rate,message',
+)
 
-    def __str__(self):
-        return ";".join((str(self.type), str(self.id), self.timestamp.isoformat(" "), str(self.price), str(self.volume), str(self.oi), str(self.order_id)))
-
-class AuxInfoEntry:
+class AuxInfoEntry(AuxInfoNamedTuple):
     class DataFlag:
         DATETIME     = 1
         ASK_TOTAL    = 2
@@ -111,47 +101,28 @@ class AuxInfoEntry:
         RATE         = 64
         MESSAGE      = 128
 
-    def __init__(self, timestamp, price, ask_total, bid_total, oi, hi_limit, low_limit, deposit, rate, message):
-        self.timestamp = timestamp
-        self.price     = price
-        self.ask_total = ask_total
-        self.bid_total = bid_total
-        self.oi        = oi
-        self.hi_limit  = hi_limit
-        self.low_limit = low_limit
-        self.deposit   = deposit
-        self.rate      = rate
-        self.message   = message
+MessageNamedTuple = namedtuple(
+    'MessageNamedTuple',
+    'timestamp,type,text',
+)
 
-    def __str__(self):
-        return ";".join((self.timestamp.isoformat(" "), str(self.price), str(self.ask_total), str(self.bid_total), str(self.oi), str(self.hi_limit), str(self.low_limit), str(self.deposit), str(self.rate), str(self.message)))
-
-class Message:
+class Message(MessageNamedTuple):
     class Type:
         INFORMATION = 1
         WARNING     = 2
         ERROR       = 3
 
-    def __init__(self, timestamp, message_type, text):
-        self.timestamp = timestamp
-        self.type      = message_type
-        self.text      = text
+OwnTrade = namedtuple(
+    'OwnTradeNamedTuple',
+    'timestamp,trade_id,order_id,price,volume',
+)
 
-    def __str__(self):
-        return ";".join((self.timestamp.isoformat(" "), str(self.type), str(self.text)))
+OwnOrderNamedTuple = namedtuple(
+    'OwnOrderNamedTuple',
+    'type,id,price,amount_rest',
+)
 
-class OwnTrade:
-    def __init__(self, timestamp, trade_id, order_id, price, volume):
-        self.timestamp = timestamp
-        self.trade_id  = trade_id
-        self.order_id  = order_id
-        self.price     = price
-        self.volume    = volume
-
-    def __str__(self):
-        return ";".join((self.timestamp.isoformat(" "), str(self.trade_id), str(self.order_id), str(self.price), str(self.volume)))
-
-class OwnOrder:
+class OwnOrder(OwnOrderNamedTuple):
     class DataFlag:
         DROP_ALL = 1
         ACTIVE   = 2
@@ -162,15 +133,6 @@ class OwnOrder:
         NONE    = 0
         REGULAR = 1
         STOP    = 2
-
-    def __init__(self, order_type, order_id, price, amount_rest):
-        self.type        = order_type
-        self.id          = order_id
-        self.price       = price
-        self.amount_rest = amount_rest
-
-    def __str__(self):
-        return ";".join((str(self.type), str(self.id), str(self.price), str(self.amount_rest)))
 
 class QshFile:
 


### PR DESCRIPTION
To have better visibility and smaller memory footprint

## How to test
```
import logging
import sys

import qsh

logger = logging.getLogger(__name__)


def get_size(obj, seen=None):
    """Recursively finds size of objects"""
    size = sys.getsizeof(obj)
    if seen is None:
        seen = set()
    obj_id = id(obj)
    if obj_id in seen:
        return 0
    seen.add(obj_id)
    if isinstance(obj, dict):
        size += sum([get_size(v, seen) for v in obj.values()])
        size += sum([get_size(k, seen) for k in obj.keys()])
    elif hasattr(obj, '__dict__'):
        size += get_size(obj.__dict__, seen)
    elif hasattr(obj, '__iter__') and not isinstance(obj, (str, bytes, bytearray)):
        size += sum([get_size(i, seen) for i in obj])
    return size


def main(filename):
    with qsh.open(filename) as qsh_file:
        stream_type, stream_info = qsh_file.read_stream_header()
        try:
            counter = 0
            while True:
                frame_timestamp, _ = qsh_file.read_frame_header()
                ord_log_entry, aux_info_entry, updated_quotes, deal_entry = qsh_file.read_ord_log_data()
                counter += 1
                yield ord_log_entry
        except EOFError:
            logger.info('Went over %d rows', counter)


if __name__ == '__main__':
    logging.basicConfig(level=logging.INFO)
    for path in sys.argv[1:]:
        ok = errors = 0
        logger.info('Trying %s', path)
        for filename in glob.glob(path + '/*.qsh'):
            logger.info('Open %s', filename)
            try:
                rows = list(main(filename))
                logger.info('Size of %d rows: %s', len(rows), get_size(rows))
                logger.info('First row: %s', rows[0])
                ok += 1
            except Exception as ex:
                logger.exception('Cannot iterate over %s', filename)
                errors += 1
            break

        logger.info('Directory %s contains %d OK files and %d corrupted files', ok + errors, ok, errors)
```

## Before
About 10k entries take 11.59Mb in memory

```
INFO:__main__:Trying data/2018-12-07
INFO:__main__:Open data/2018-12-07/AFKS.2018-12-07.AuxInfo.qsh
INFO:__main__:Went over 9777 rows
INFO:__main__:Size of 9777 rows: 12153494
INFO:__main__:First row: 45305;0001-01-01 00:00:00+02:30;1;26974;0;0;0;0;0
INFO:__main__:Directory 1 contains 1 OK files and 0 corrupted files
```

## After
The same data takes 3.95Mb in memory
```
INFO:__main__:Trying data/2018-12-07
INFO:__main__:Open data/2018-12-07/AFKS.2018-12-07.AuxInfo.qsh
INFO:__main__:Went over 9777 rows
INFO:__main__:Size of 9777 rows: 4150352
INFO:__main__:First row: OrdLogNamedTuple(actions_mask=45305, exchange_timestamp=datetime.datetime(1, 1, 1, 0, 0, tzinfo=tzfile('/usr/share/zoneinfo/Europe/Moscow')), exchange_order_id=1, order_price=26974, amount=0, amount_rest=0, deal_id=0, deal_price=0, oi_after_deal=0)
INFO:__main__:Directory 1 contains 1 OK files and 0 corrupted files
```

## Risks
Names of constructor arguments were changed, so keyword-like instantiation may be broken. While positinal args are OK and new arg-names are fine too.
For example:
```
>>> import qsh
>>> qsh.OwnOrder(order_type=0, order_id=123, price=1234, amount_rest=10)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: __new__() got an unexpected keyword argument 'order_id'
>>> qsh.OwnOrder(type=0, id=123, price=1234, amount_rest=10)
OwnOrderNamedTuple(type=0, id=123, price=1234, amount_rest=10)
>>> qsh.OwnOrder(0, 123, 1234, 10)
OwnOrderNamedTuple(type=0, id=123, price=1234, amount_rest=10)
```